### PR TITLE
Nuuly templates changes

### DIFF
--- a/dm/templates/autoscaler/autoscaler.py.schema
+++ b/dm/templates/autoscaler/autoscaler.py.schema
@@ -19,8 +19,6 @@ info:
     Creates an autoscaler.
     See https://cloud.google.com/compute/docs/autoscaler/ for more details.
 
-additionalProperties: false
-
 required:
   - maxNumReplicas
   - target

--- a/dm/templates/backend_service/backend_service.py.schema
+++ b/dm/templates/backend_service/backend_service.py.schema
@@ -19,8 +19,6 @@ info:
     Creates a backend service. For details, visit
     https://cloud.google.com/load-balancing/docs/backend-service.
 
-additionalProperties: false
-
 properties:
   name:
     type: string

--- a/dm/templates/bastion/bastion.py.schema
+++ b/dm/templates/bastion/bastion.py.schema
@@ -23,8 +23,6 @@ imports:
   - path: ../instance/instance.py
     name: instance.py
 
-additionalProperties: false
-
 required:
   - zone
   - network

--- a/dm/templates/bigquery/bigquery_dataset.py.schema
+++ b/dm/templates/bigquery/bigquery_dataset.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: bigquery_dataset.py
 
-additionalProperties: false
-
 required:
   - name
 

--- a/dm/templates/bigquery/bigquery_dataset.py.schema
+++ b/dm/templates/bigquery/bigquery_dataset.py.schema
@@ -46,7 +46,7 @@ properties:
     description: |
       An array of objects that define dataset access for one or more
       entities. You can set this property when inserting or updating
-      the dataset to control who is allowed to access the data. If not 
+      the dataset to control who is allowed to access the data. If not
       specified at the dataset creation time, BigQuery defines default
       dataset access for the following entities:
         access.specialGroup: projectReaders; access.role: READER
@@ -59,7 +59,7 @@ properties:
         description: |
           The role (rights) granted to the user specified by the other
           member of the access object. The following string values are
-          supported: READER, WRITER, OWNER. See details at 
+          supported: READER, WRITER, OWNER. See details at
           https://cloud.google.com/bigquery/docs/access-control.
         enum:
           - READER
@@ -69,7 +69,7 @@ properties:
         - domain:
           type: string
           description: |
-            The domain to grant access to. All users signed in with the 
+            The domain to grant access to. All users signed in with the
             specified domain are granted the corresponding access.
             Example: "example.com".
         - userByEmail:
@@ -94,7 +94,7 @@ properties:
             A view from a different dataset to grant access to. Queries
             executed against that view have the Read access to tables in that
             dataset. The Role value is not required when this field is set. If
-            the view is updated, access to that view must be granted again 
+            the view is updated, access to that view must be granted again
             via an Update operation.
           properties:
             datasetId:
@@ -117,7 +117,7 @@ properties:
     type: boolean
     default: False
     description: |
-      Defines whether the default project service is granted the IAM owner 
+      Defines whether the default project service is granted the IAM owner
       permissions.
   defaultTableExpirationMs:
     type: string
@@ -126,9 +126,9 @@ properties:
       The default lifetime of all tables in the dataset, in milliseconds. The
       minimum value is 3600000 milliseconds (one hour). Once this property is
       set, all newly-created tables in the dataset get their expirationTime
-      property set to the creation time plus the value of this property. 
+      property set to the creation time plus the value of this property.
       Changes to the value affect only new tables, not the existing ones. When
-      expirationTime for a given table is reached, that table is deleted 
+      expirationTime for a given table is reached, that table is deleted
       automatically. If a table's expirationTime is modified or
       removed before the table expires, or if you provide an explicit
       expirationTime while creating the table, that value takes precedence over

--- a/dm/templates/bigquery/bigquery_table.py
+++ b/dm/templates/bigquery/bigquery_table.py
@@ -36,6 +36,7 @@ def generate_config(context):
         'expirationTime',
         'schema',
         'timePartitioning',
+        'clustering',
         'view'
     ]
 

--- a/dm/templates/bigquery/bigquery_table.py
+++ b/dm/templates/bigquery/bigquery_table.py
@@ -18,12 +18,13 @@
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    name = context.properties['name']
+    table_id = context.properties['name']
+    name = context.env['name']
 
     properties = {
         'tableReference':
             {
-                'tableId': name,
+                'tableId': table_id,
                 'datasetId': context.properties['datasetId'],
                 'projectId': context.env['project']
             },
@@ -58,6 +59,15 @@ def generate_config(context):
         }
     ]
 
+    # Add additional dependencies
+    if 'view' in context.properties and \
+       'additionalDependencies' in context.properties['view']:
+        deps = [
+            d['name']
+            for d in context.properties['view']['additionalDependencies']
+        ]
+        resources[0]['metadata']['dependsOn'].extend(deps)
+
     outputs = [
         {
             'name': 'selfLink',
@@ -90,6 +100,10 @@ def generate_config(context):
         {
             'name': 'numRows',
             'value': '$(ref.{}.numRows)'.format(name)
+        },
+        {
+            'name': 'tableId',
+            'value': table_id
         },
         {
             'name': 'type',

--- a/dm/templates/bigquery/bigquery_table.py.schema
+++ b/dm/templates/bigquery/bigquery_table.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: bigquery_table.py
 
-additionalProperties: false
-
 required:
   - name
 
@@ -76,6 +74,19 @@ properties:
         description: |
           The only supported type is DAY, which generates one partition
           per day.
+  clustering:
+    type: object
+    description: The clustering specification for this table.
+    properties:
+      fields:
+        type: array
+        description: |
+          One or more fields on which data should be clustered.
+          Only top-level, non-repeated, simple-type fields are supported.
+          The order of the fields will determine how clusters
+          will be generated, so it is important.
+        items:
+          type: string
   view:
     type: object
     description: The view definintion.
@@ -134,7 +145,7 @@ properties:
           description: |
             The field data type. Possible values are STRING, BYTES,
             INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as
-            FLOAT), BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME,
+            FLOAT), NUMERIC, BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME,
             DATETIME, RECORD (indicates that the field contains a nested 
             schema), and STRUCT (same as RECORD). See details at 
             https://cloud.google.com/bigquery/docs/schemas and 
@@ -146,6 +157,7 @@ properties:
             - INT64
             - FLOAT
             - FLOAT64
+            - NUMERIC
             - BOOLEAN
             - BOOL
             - TIMESTAMP

--- a/dm/templates/bigquery/bigquery_table.py.schema
+++ b/dm/templates/bigquery/bigquery_table.py.schema
@@ -41,7 +41,7 @@ properties:
     type: string
     description: |
       The time when the table expires, in milliseconds since the epoch. If
-      not specified, the table persists indefinitely. Expired tables are 
+      not specified, the table persists indefinitely. Expired tables are
       deleted, and their storage is reclaimed. The defaultTableExpirationMs
       property of the encapsulating dataset can be used to set a default
       expirationTime on newly created tables. For example, 1535739430.
@@ -59,11 +59,11 @@ properties:
       field:
         type: string
         description: |
-          The field to be used for table partitioning. This field must be a top-level 
+          The field to be used for table partitioning. This field must be a top-level
           TIMESTAMP or DATE field. Its mode must be NULLABLE or REQUIRED.
-          If not specified, the table is partitioned by a pseudo-column, 
-          referenced via either '_PARTITIONTIME' as TIMESTAMP type or 
-          '_PARTITIONDATE' as DATE type. 
+          If not specified, the table is partitioned by a pseudo-column,
+          referenced via either '_PARTITIONTIME' as TIMESTAMP type or
+          '_PARTITIONDATE' as DATE type.
       requirePartitionFilter:
         type: boolean
         description: |
@@ -91,6 +91,20 @@ properties:
     type: object
     description: The view definintion.
     properties:
+      additionalDependencies:
+        type: array
+        description: |
+          A list of additional resources the table/view depends on beyond
+          the defined dataset. These may be referenced in the view's SQL
+        items:
+          type: object
+          description: List of resource dependencies
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: Resource dependency name (i.e. table name)
       query:
         type: string
         description: |
@@ -113,7 +127,7 @@ properties:
               type: string
               description: |
                 The inline resource that contains code for a user-defined
-                function (UDF). An equivalent a URI for a file containing 
+                function (UDF). An equivalent a URI for a file containing
                 the same code.
             - resourceUri:
               type: string
@@ -146,9 +160,9 @@ properties:
             The field data type. Possible values are STRING, BYTES,
             INTEGER, INT64 (same as INTEGER), FLOAT, FLOAT64 (same as
             FLOAT), NUMERIC, BOOLEAN, BOOL (same as BOOLEAN), TIMESTAMP, DATE, TIME,
-            DATETIME, RECORD (indicates that the field contains a nested 
-            schema), and STRUCT (same as RECORD). See details at 
-            https://cloud.google.com/bigquery/docs/schemas and 
+            DATETIME, RECORD (indicates that the field contains a nested
+            schema), and STRUCT (same as RECORD). See details at
+            https://cloud.google.com/bigquery/docs/schemas and
             https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types.
           enum:
             - STRING
@@ -196,7 +210,7 @@ outputs:
     - lastModifiedTime:
         type: string
         description: |
-          The date when the dataset (or any of its tables) was last 
+          The date when the dataset (or any of its tables) was last
           modified, in milliseconds since the epoch.
     - location:
         type: string
@@ -219,14 +233,17 @@ outputs:
         description: |
           The number of rows of data in the table, excluding data in the
           streaming buffer.
+    - tableId:
+        type: string
+        description: The table ID (name) of the created resource.
     - type:
         type: string
         description: |
-          The table type. The following values are supported: 
+          The table type. The following values are supported:
            TABLE - a normal BigQuery table
            VIEW - a virtual table defined by an SQL query
            EXTERNAL - a table that references data stored in an external
-           storage system, such as Google Cloud Storage. 
+           storage system, such as Google Cloud Storage.
           The default value is TABLE.
 
 documentation:

--- a/dm/templates/cloud_function/cloud_function.py.schema
+++ b/dm/templates/cloud_function/cloud_function.py.schema
@@ -20,8 +20,6 @@ info:
     or a cloud source repository, and then assigns HTTPS, Storage, or Pub/Sub 
     trigger to that Cloud Function.
 
-additionalProperties: false
-
 required:
   - region
 

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -24,8 +24,6 @@ info:
 imports:
   - path: cloud_router.py
 
-additionalProperties: false
-
 required:
   - network
   - region

--- a/dm/templates/cloud_spanner/cloud_spanner.py.schema
+++ b/dm/templates/cloud_spanner/cloud_spanner.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Creates a Cloud Spanner instance and database.
 
-additionalProperties: false
-
 required:
   - displayName
   - nodeCount

--- a/dm/templates/cloud_sql/cloud_sql.py.schema
+++ b/dm/templates/cloud_sql/cloud_sql.py.schema
@@ -22,8 +22,6 @@ info:
 imports:
   - path: cloud_sql.py
 
-additionalProperties: false
-
 required:
   - region
   - settings

--- a/dm/templates/cloud_tasks/queue.py.schema
+++ b/dm/templates/cloud_tasks/queue.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: queue.py
 
-additionalProperties: false
-
 required:
   - name
 

--- a/dm/templates/cloudbuild/cloudbuild.py.schema
+++ b/dm/templates/cloudbuild/cloudbuild.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: cloudbuild.py
 
-additionalProperties: false
-
 required:
   - steps
 

--- a/dm/templates/dataproc/dataproc.py.schema
+++ b/dm/templates/dataproc/dataproc.py.schema
@@ -21,8 +21,6 @@ info:
 imports:
   - path: dataproc.py
 
-additionalProperties: false
-
 properties:
   name:
     type: string

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py
@@ -22,7 +22,7 @@ def generate_config(context):
     managed_zone_name = context.properties.get('zoneName')
     dnsname = context.properties['dnsName']
     managed_zone_description = context.properties['description']
-    name_servers = '$(ref.' + context.env['name'] + '.nameServers)'
+    name_servers = '$(ref.' + context.properties['zoneName'] + '.nameServers)'
 
     managed_zone = {
         'name': context.env['name'],

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: dns_managed_zone.py
 
-additionalProperties: false
-
 required:
   - zoneName
   - dnsName
@@ -32,12 +30,9 @@ required:
 properties:
   zoneName:
     type: string
-    pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
     description: |
       A user-assigned name for the managed zone.
       This is required by the Cloud DNS.
-      Must be 1-63 characters long, must begin with a letter,
-      end with a letter or digit, and only contain lowercase letters, digits or dashes.
   dnsName:
     type: string
     pattern: \.$

--- a/dm/templates/dns_managed_zone/tests/integration/dns_managed_zone.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_managed_zone.yaml
@@ -6,7 +6,7 @@ imports:
     name: dns_managed_zone.py
 
 resources:
-  - name: ${CLOUDDNS_ZONE_NAME}-resource
+  - name: ${CLOUDDNS_ZONE_NAME}
     type: dns_managed_zone.py
     properties:
       zoneName: ${CLOUDDNS_ZONE_NAME}

--- a/dm/templates/dns_records/dns_records.py.schema
+++ b/dm/templates/dns_records/dns_records.py.schema
@@ -24,8 +24,6 @@ info:
 imports:
   - path: dns_records.py
 
-additionalProperties: false
-
 required:
   - zoneName
   - dnsName

--- a/dm/templates/external_load_balancer/external_load_balancer.py.schema
+++ b/dm/templates/external_load_balancer/external_load_balancer.py.schema
@@ -31,8 +31,6 @@ imports:
   - path: ../target_proxy/target_proxy.py
     name: target_proxy.py
 
-additionalProperties: false
-
 properties:
   name:
     type: string

--- a/dm/templates/firewall/firewall.py.schema
+++ b/dm/templates/firewall/firewall.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Deploys firewall rules
 
-additionalProperties: false
-
 required:
   - rules
 

--- a/dm/templates/folder/folder.py.schema
+++ b/dm/templates/folder/folder.py.schema
@@ -21,8 +21,6 @@ info:
 imports:
   - path: folder.py
 
-additionalProperties: false
-
 required:
   - folders
 
@@ -61,7 +59,7 @@ outputs:
       items:
         description: |
           The name of the folder resource. For example, the output can be
-          referenced as: $(ref.<my-folder>.rules.<folder-name>.parent)
+          referenced as: $(ref.<my-folder>.folders.<folder-name>.parent)
         patternProperties:
           ".*":
             type: object

--- a/dm/templates/forseti/client.py.schema
+++ b/dm/templates/forseti/client.py.schema
@@ -21,8 +21,6 @@ info:
 imports:
   - path: client.py
 
-additionalProperties: false
-
 required:
   - project
   - zone

--- a/dm/templates/forwarding_rule/forwarding_rule.py.schema
+++ b/dm/templates/forwarding_rule/forwarding_rule.py.schema
@@ -20,8 +20,6 @@ info:
     See https://cloud.google.com/load-balancing/docs/forwarding-rules for
     details.
 
-additionalProperties: false
-
 properties:
   name:
     type: string

--- a/dm/templates/gcs_bucket/gcs_bucket.py
+++ b/dm/templates/gcs_bucket/gcs_bucket.py
@@ -34,11 +34,8 @@ def generate_config(context):
         }
     }
 
-    requesterPays = context.properties.get('requesterPays')
-    if requesterPays is not None:
-      bucket['properties']['billing'] = {'requesterPays': requesterPays}
-
     optional_props = [
+        'billing',
         'location',
         'versioning',
         'storageClass',

--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -39,7 +39,7 @@ properties:
     default: STANDARD
     description: |
       The bucket's default storage class. Defines how objects
-      in the bucket are stored; determines the SLA and the 
+      in the bucket are stored; determines the SLA and the
       cost of storage.
     enum:
       - REGIONAL
@@ -95,7 +95,7 @@ properties:
       logBucket:
         type: string
         description: |
-          The destination bucket where the current bucket's logs 
+          The destination bucket where the current bucket's logs
           must be placed.
       logObjectPrefix:
         type: string
@@ -130,6 +130,31 @@ properties:
         type: boolean
         description: |
           When set to true, Requester Pays is enabled for this bucket.
+  cors:
+    type: array
+    description: CORS specification for the bucket
+    properties:
+      maxAgeSeconds:
+        type: integer
+        description: |
+          How long the results of a preflight request (that is the information
+          contained in the Access-Control-Allow-Methods and
+          Access-Control-Allow-Headers headers) can be cached
+      method:
+        type: array
+        description: HTTP methods to apply
+        items:
+          type: string
+      origin:
+        type: array
+        description: Locations the resource can be accessed by in a cross-site manner
+        items:
+          type: string
+      responseHeader:
+        type: array
+        description: Response header entries
+        items:
+          type: string
   lifecycle:
     type: object
     description: The storage object's lifecycle actions and conditions.
@@ -151,7 +176,7 @@ properties:
               properties:
                 storageClass:
                   type: string
-                  description: 
+                  description:
                     The storage class to switch on if the condition is met.
                   enum:
                     - NEARLINE
@@ -191,14 +216,14 @@ properties:
                 isLive:
                   type: boolean
                   description: |
-                    Defines whether the object is live. Applies only to 
+                    Defines whether the object is live. Applies only to
                     versioned objects.
                 numNewerVersions:
                   type: number
                   description: |
                     The number of newer versions. Selects all objects with
                     at least that many newer versions. Applies only to
-                    versioned objects. 
+                    versioned objects.
   labels:
     type: object
     description: User-provided labels in key/value pairs.
@@ -214,7 +239,7 @@ properties:
           The suffix that allows creation of index.html objects to represent
           directory pages. If the requested object path is missing, the service
           ensures that the trailing '/' is present, appends this suffix, and
-          attempt to retrieve the resulting object. 
+          attempt to retrieve the resulting object.
       notFoundPage:
         type: string
         description: |

--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: gcs_bucket.py
 
-additionalProperties: false
-
 required:
   - name
 
@@ -92,6 +90,7 @@ properties:
     type: object
     required:
       - logBucket
+      - logObjectPrefix
     properties:
       logBucket:
         type: string
@@ -123,6 +122,14 @@ properties:
               group|serviceAccount:email or domain:domain.
               Can also be one of the following special values: allUsers,
               allAuthenticatedUsers.
+  billing:
+    type: object
+    description: The bucket's billing configuration.
+    properties:
+      requesterPays:
+        type: boolean
+        description: |
+          When set to true, Requester Pays is enabled for this bucket.
   lifecycle:
     type: object
     description: The storage object's lifecycle actions and conditions.
@@ -195,10 +202,6 @@ properties:
   labels:
     type: object
     description: User-provided labels in key/value pairs.
-  requesterPays:
-    type: boolean
-    description: |
-      When set to true, Requester Pays is enabled for this bucket.
   website:
     type: object
     description: |

--- a/dm/templates/gke/gke.py
+++ b/dm/templates/gke/gke.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """ This template creates a Google Kubernetes Engine cluster. """
 
-from packaging import version
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
@@ -113,20 +112,13 @@ def generate_config(context):
         'endpoint',
         'instanceGroupUrls',
         'clusterCaCertificate',
+        'clientCertificate',
+        'clientKey',
         'currentMasterVersion',
         'currentNodeVersion',
+        'nodeIpv4CidrSize',
         'servicesIpv4Cidr'
     ]
-
-    if (
-        version.parse(propc.get('initialClusterVersion').split('-')[0]) < version.parse("1.12") or
-        propc.get('masterAuth', {}).get('clientCertificateConfig', False)
-    ):
-        output_props.append('clientCertificate')
-        output_props.append('clientKey')
-        
-    if not propc.get('ipAllocationPolicy', {}).get('useIpAliases', False):
-        output_props.append('nodeIpv4CidrSize')
 
     for outprop in output_props:
         output_obj = {}

--- a/dm/templates/gke/gke.py.schema
+++ b/dm/templates/gke/gke.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: gke.py
 
-additionalProperties: false
-
 required:
   - cluster
 
@@ -502,6 +500,33 @@ properties:
                 type: boolean
                 description: |
                   Defines whether the NetworkPolicy add-on is enabled for
+                  the cluster.
+          istioConfig:
+            type: object
+            description: |
+              The configuration for the Istio add-on. 
+            properties:
+              disabled:
+                type: boolean
+                description: |
+                  Defines whether the Istio add-on is enabled for
+                  the cluster.
+              auth:
+                type: string
+                default: AUTH_NONE
+                description: The specified Istio auth mode, either none, or mutual TLS.
+                enum:
+                  - AUTH_NONE
+                  - AUTH_MUTUAL_TLS 
+          cloudRunConfig:
+            type: object
+            description: |
+              The configuration for the CloudRunConfig add-on.
+            properties:
+              disabled:
+                type: boolean
+                description: |
+                  Defines whether the CloudRunConfig add-on is enabled for
                   the cluster.
       maintenancePolicy:
         type: object

--- a/dm/templates/haproxy/haproxy.py.schema
+++ b/dm/templates/haproxy/haproxy.py.schema
@@ -22,8 +22,6 @@ info:
 imports:
   - path: haproxy.py
 
-additionalProperties: false
-
 required:
   - zone
   - network

--- a/dm/templates/healthcheck/examples/healthcheck.yaml
+++ b/dm/templates/healthcheck/examples/healthcheck.yaml
@@ -15,7 +15,7 @@ resources:
     healthyThreshold: 2
     host: my-host.testing
     port: 80
-    healthcheck_type: HTTP
+    healthcheckType: HTTP
 - name: my-legacy-https-healthcheck-local
   type: healthcheck.py
   properties:
@@ -25,7 +25,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: HTTPS
+    healthcheckType: HTTPS
 - name: my-beta-http-healthcheck-local
   type: healthcheck.py
   properties:
@@ -36,7 +36,7 @@ resources:
     healthyThreshold: 2
     host: my-host.testing
     port: 80
-    healthcheck_type: HTTP
+    healthcheckType: HTTP
     response: my-response
     version: beta
 - name: my-beta-https-healthcheck-local
@@ -49,7 +49,7 @@ resources:
     healthyThreshold: 2
     host: my-host.testing
     port: 80
-    healthcheck_type: HTTPS
+    healthcheckType: HTTPS
     response: my-response
     version: beta
 - name: my-beta-http2-healthcheck-local
@@ -61,7 +61,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: HTTP2
+    healthcheckType: HTTP2
     version: beta
 - name: my-tcp-healthcheck-local
   type: healthcheck.py
@@ -72,7 +72,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: TCP
+    healthcheckType: TCP
 - name: my-ssl-healthcheck-local
   type: healthcheck.py
   properties:
@@ -82,7 +82,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: SSL
+    healthcheckType: SSL
 - name: my-beta-tcp-healthcheck
   type: healthcheck.py
   properties:
@@ -92,7 +92,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: TCP
+    healthcheckType: TCP
 - name: my-beta-ssl-healthcheck
   type: healthcheck.py
   properties:
@@ -102,7 +102,7 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     port: 80
-    healthcheck_type: SSL
+    healthcheckType: SSL
 - name: my-requestpath-healthcheck-local
   type: healthcheck.py
   properties:
@@ -113,7 +113,7 @@ resources:
     healthyThreshold: 2
     proxyHeader: PROXY_V1
     requestPath: /health.html
-    healthcheck_type: HTTPS
+    healthcheckType: HTTPS
 - name: my-response-healthcheck-local
   type: healthcheck.py
   properties:
@@ -123,6 +123,6 @@ resources:
     unhealthyThreshold: 2
     healthyThreshold: 2
     proxyHeader: PROXY_V1
-    healthcheck_type: TCP
+    healthcheckType: TCP
     request: request-data
     response: response-data

--- a/dm/templates/healthcheck/healthcheck.py.schema
+++ b/dm/templates/healthcheck/healthcheck.py.schema
@@ -24,8 +24,6 @@ info:
 imports:
   - path: healthcheck.py
 
-additionalProperties: false
-
 required:
   - healthcheckType
 

--- a/dm/templates/iam_custom_role/organization_custom_role.py.schema
+++ b/dm/templates/iam_custom_role/organization_custom_role.py.schema
@@ -36,8 +36,6 @@ info:
 imports:
   - path: organization_custom_role.py
 
-additionalProperties: false
-
 required:
   - orgId
   - roleId

--- a/dm/templates/iam_custom_role/project_custom_role.py.schema
+++ b/dm/templates/iam_custom_role/project_custom_role.py.schema
@@ -36,8 +36,6 @@ info:
 imports:
   - path: project_custom_role.py
 
-additionalProperties: false
-
 required:
   - roleId
   - includedPermissions

--- a/dm/templates/iam_member/iam_member.py.schema
+++ b/dm/templates/iam_member/iam_member.py.schema
@@ -20,8 +20,6 @@ info:
 imports:
   - path: iam_member.py
 
-additionalProperties: false
-
 required:
   - roles
 

--- a/dm/templates/instance/examples/instance.yaml
+++ b/dm/templates/instance/examples/instance.yaml
@@ -12,10 +12,10 @@ resources:
     properties:
       zone: us-central1-a
       diskImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts
+      diskSizeGb: 100
       machineType: f1-micro
       diskType: pd-ssd
-      networks:
-        - name: default
+      network: default
       metadata:
         items:
           - key: startup-script

--- a/dm/templates/instance/instance.py.schema
+++ b/dm/templates/instance/instance.py.schema
@@ -25,69 +25,7 @@ required:
   - zone
   - machineType
   - diskImage
-
-oneOf:
-  - allOf:
-    - required:
-        - networks
-    - properties:
-        networks:
-          minItems: 1
-    - not:
-        required:
-          - network
-    - not:
-        required:
-          - natIP
-    - not:
-        required:
-          - subnetwork
-    - not:
-        required:
-          - networkIP
-  - allOf:
-    - required:
-        - network
-    - not:
-       required:
-         - networks
-
-additionalProperties: false
-
-definitions:
-    hasExternalIp:
-      type: boolean
-      default: true
-      description: |
-        Defines wether the instance will use an external IP from a shared
-        ephemeral IP address pool. If this is set to false, the instance
-        will not have an external IP.
-    natIP:
-      type: string
-      description: |
-        An external IP address associated with this instance. Specify an unused
-        static external IP address available to the project or leave this field
-        undefined to use an IP from a shared ephemeral IP address pool. If you
-        specify a static external IP address, it must live in the same region
-        as the zone of the instance.
-        If hasExternalIp is false this field is ignored.
-    subnetwork:
-      type: string
-      description: |
-        The URL of the Subnetwork resource for this instance. If the network
-        resource is in legacy mode, do not provide this property. If the network
-        is in auto subnet mode, providing the subnetwork is optional. If the
-        network is in custom subnet mode, then this field should be specified.
-        If you specify this property, you can specify the subnetwork as a full
-        or partial URL. For example, the following are all valid URLs:
-          - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
-          - regions/region/subnetworks/subnetwork
-    networkIP:
-      type: string
-      description: |
-        An IPv4 internal network address to assign to the instance for this
-        network interface. If not specified by the user, an unused internal IP
-        is assigned by the system.
+  - network
 
 properties:
   name:
@@ -98,41 +36,42 @@ properties:
     description: |
       Name of the network the instance will be connected to;
       e.g., 'my-custom-network' or 'default'.
-  hasExternalIp:
-    $ref: '#/definitions/hasExternalIp'
-  natIP:
-    $ref: '#/definitions/natIP'
-  subnetwork:
-    $ref: '#/definitions/subnetwork'
-  networkIP:
-    $ref: '#/definitions/networkIP'
-  networks:
-    type: array
-    description: |
-      Networks the instance will be connected to;
-      e.g., 'my-custom-network' or 'default'.
-    items:
-      type: object
-      additionalProperties: false
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: |
-            Name of the network the instance will be connected to;
-            e.g., 'my-custom-network' or 'default'.
-        hasExternalIp:
-          $ref: '#/definitions/hasExternalIp'
-        natIP:
-          $ref: '#/definitions/natIP'
-        subnetwork:
-          $ref: '#/definitions/subnetwork'
-        networkIP:
-          $ref: '#/definitions/networkIP'
   zone:
     type: string
     description: Availability zone. E.g. 'us-central1-a'
+  hasExternalIp:
+    type: boolean
+    default: true
+    description: |
+      Defines wether the instance will use an external IP from a shared
+      ephemeral IP address pool. If this is set to false, the instance
+      will not have an external IP.
+  natIp:
+    type: string
+    description: |
+      An external IP address associated with this instance. Specify an unused
+      static external IP address available to the project or leave this field
+      undefined to use an IP from a shared ephemeral IP address pool. If you
+      specify a static external IP address, it must live in the same region
+      as the zone of the instance.
+      If hasExternalIp is false this field is ignored.
+  subnetwork:
+    type: string
+    description: |
+      The URL of the Subnetwork resource for this instance. If the network
+      resource is in legacy mode, do not provide this property. If the network
+      is in auto subnet mode, providing the subnetwork is optional. If the
+      network is in custom subnet mode, then this field should be specified.
+      If you specify this property, you can specify the subnetwork as a full
+      or partial URL. For example, the following are all valid URLs:
+        - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
+        - regions/region/subnetworks/subnetwork
+  networkIp:
+    type: string
+    description: |
+      An IPv4 internal network address to assign to the instance for this
+      network interface. If not specified by the user, an unused internal IP
+      is assigned by the system.
   tags:
     type: object
     description: |
@@ -156,7 +95,6 @@ properties:
       See https://cloud.google.com/compute/docs/machine-types for details.
   canIpForward:
     type: boolean
-    default: False
     description: |
       If "True". allows the instance to send and receive packets with non-matching destination
       and source IPs.
@@ -169,12 +107,11 @@ properties:
       - local-ssd
   diskImage:
     type: string
-    default: None
     description: |
       The source image for the disk. To create the disk with one of the
       public operating system images, specify the image by its family name.
-      For example, use "projects/debian-cloud/global/images/family/debian-9" 
-      to install the latest Debian 9 image.
+      For example, specify family/debian-9 to use the latest Debian 9 image
+      projects/debian-cloud/global/images/family/debian-9.
       To create a disk with a custom image (that you created), specify the image
       name in the following format: global/images/my-custom-image.
       See https://cloud.google.com/compute/docs/images for details.
@@ -197,7 +134,6 @@ properties:
         description: A collection of metadata key-value pairs.
         items:
           type: object
-          additionalProperties: false
           properties:
             key:
               type: string
@@ -210,7 +146,6 @@ properties:
       this instance. Only one service account per VM instance is supported.
     items:
       type: object
-      additionalProperties: false
       properties:
         email:
           type: string
@@ -227,19 +162,12 @@ properties:
 
 outputs:
   properties:
-    - networkInterfaces:
-      type: array
-      description: |
-        A list of network interfaces of the new instance.
-      items:
-        type: object
-        properties:
-          externalIp:
-            type: string
-            description: Reference to the external ip address of the new instance
-          internalIp:
-            type: string
-            description: Reference to tbe internal ip address of the new instance
+    - externalIp:
+        type: string
+        description: Reference to the external ip address of the new instance
+    - internalIp:
+        type: string
+        description: Reference to tbe internal ip address of the new instance
     - name:
         type: string
         description: A name of the instance resource
@@ -252,3 +180,4 @@ documentation:
 
 examples:
   - templates/instance/examples/instance.yaml
+

--- a/dm/templates/instance_template/examples/instance_template.yaml
+++ b/dm/templates/instance_template/examples/instance_template.yaml
@@ -11,8 +11,7 @@ resources:
     type: instance_template.py
     properties:
       diskImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts
-      networks:
-        - default
+      network: default
       machineType: f1-micro
       tags:
         items:

--- a/dm/templates/instance_template/instance_template.py.schema
+++ b/dm/templates/instance_template/instance_template.py.schema
@@ -18,38 +18,27 @@ info:
   description: |
     Creates an instance template.
 
-additionalProperties: false
-
 required:
   - diskImage
+  - network
 
-oneOf:
-  - allOf:
-    - required:
-        - networks
-    - properties:
-        networks:
-          minItems: 1
-    - not:
-        required:
-          - network
-    - not:
-        required:
-          - natIP
-    - not:
-        required:
-          - subnetwork
-    - not:
-        required:
-          - networkIP
-  - allOf:
-    - required:
-        - network
-    - not:
-       required:
-         - networks
-
-definitions:
+properties:
+  name:
+    type: string
+    description: The name of the instance template resource.
+  templateDescription:
+    type: string
+    description: The resource description (optional).
+  instanceDescription:
+    type: string
+    description: |
+      The description of the instance resource the instance template
+      will create (optional).
+  network:
+    type: string
+    description: |
+      The URL or name of the network where the instance is placed;
+      e.g., 'my-custom-network' or 'global/networks/default'.
   hasExternalIp:
     type: boolean
     default: true
@@ -57,7 +46,7 @@ definitions:
       Defines wether the instance will use an external IP from a shared
       ephemeral IP address pool. If this is set to false, the instance
       will not have an external IP.
-  natIP:
+  natIp:
     type: string
     description: |
       An external IP address associated with this instance. Specify an unused
@@ -77,62 +66,12 @@ definitions:
       or partial URL. For example, the following are all valid URLs:
         - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
         - regions/region/subnetworks/subnetwork
-  networkIP:
+  networkIp:
     type: string
     description: |
       An IPv4 internal network address to assign to the instance for this
       network interface. If not specified by the user, an unused internal IP
       is assigned by the system.
-
-properties:
-  name:
-    type: string
-    description: The name of the instance template resource.
-  templateDescription:
-    type: string
-    description: The resource description (optional).
-  instanceDescription:
-    type: string
-    description: |
-      The description of the instance resource the instance template
-      will create (optional).
-  network:
-    type: string
-    description: |
-      Name of the network the instance will be connected to;
-      e.g., 'my-custom-network' or 'default'.
-  hasExternalIp:
-    $ref: '#/definitions/hasExternalIp'
-  natIP:
-    $ref: '#/definitions/natIP'
-  subnetwork:
-    $ref: '#/definitions/subnetwork'
-  networkIP:
-    $ref: '#/definitions/networkIP'
-  networks:
-    type: array
-    description: |
-      Networks the instance will be connected to;
-      e.g., 'my-custom-network' or 'default'.
-    items:
-      type: object
-      additionalProperties: false
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: |
-            Name of the network the instance will be connected to;
-            e.g., 'my-custom-network' or 'default'.
-        hasExternalIp:
-          $ref: '#/definitions/hasExternalIp'
-        natIP:
-          $ref: '#/definitions/natIP'
-        subnetwork:
-          $ref: '#/definitions/subnetwork'
-        networkIP:
-          $ref: '#/definitions/networkIP'
   machineType:
     type: string
     default: n1-standard-1
@@ -142,7 +81,7 @@ properties:
   canIpForward:
     type: boolean
     description: |
-      Defines whether the instance is allowed to send and receive packets
+      Defines whether the instance is allowed to send and receive packets 
       with non-matching destination or source IPs.
   diskType:
     type: string

--- a/dm/templates/interconnect/interconnect.py.schema
+++ b/dm/templates/interconnect/interconnect.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: interconnect.py
 
-additionalProperties: false
-
 required:
   - name
   - customerName

--- a/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
+++ b/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
@@ -25,8 +25,6 @@ info:
 imports:
   - path: interconnect_attachment.py
 
-additionalProperties: false
-
 required:
   - router
   - region

--- a/dm/templates/internal_load_balancer/internal_load_balancer.py.schema
+++ b/dm/templates/internal_load_balancer/internal_load_balancer.py.schema
@@ -26,8 +26,6 @@ imports:
   - path: ../forwarding_rule/forwarding_rule.py
     name: forwarding_rule.py
 
-additionalProperties: false
-
 required:
   - region
   - backendService

--- a/dm/templates/ip_reservation/ip_address.py.schema
+++ b/dm/templates/ip_reservation/ip_address.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Creates an internal, external, or global IP address.
 
-additionalProperties: false
-
 required:
   - name
   - ipType

--- a/dm/templates/ip_reservation/ip_reservation.py.schema
+++ b/dm/templates/ip_reservation/ip_reservation.py.schema
@@ -21,8 +21,6 @@ imports:
   - path: ../ip_reservation/ip_address.py
     name: ip_address.py
 
-additionalProperties: false
-
 required:
   - ipAddresses
 

--- a/dm/templates/kms/kms.py
+++ b/dm/templates/kms/kms.py
@@ -43,7 +43,7 @@ def generate_config(context):
     for key in properties.get('keys', []):
         key_name = key['cryptoKeyName'].lower()
         crypto_key = {
-            'name': key_name,
+            'name': '{}-{}'.format(keyring_name, key_name),
             'type': provider + '.cryptoKeys',
             'properties':
                 {

--- a/dm/templates/kms/kms.py.schema
+++ b/dm/templates/kms/kms.py.schema
@@ -65,9 +65,9 @@ properties:
           description: |
             The time when the Key Management Service will automatically
             create a new version of the CryptoKey and mark the new version
-            as primary. Keys with the ENCRYPT_DECRYPT purpose support 
-            automatic rotation. For all other keys, this field must be left 
-            blank. The timestamp is in the RFC3339 UTC "Zulu" format, 
+            as primary. Keys with the ENCRYPT_DECRYPT purpose support
+            automatic rotation. For all other keys, this field must be left
+            blank. The timestamp is in the RFC3339 UTC "Zulu" format,
             accurate to nanoseconds; e.g., "2014-10-02T15:01:23.045123456Z".
         rotationPeriod:
           type: string
@@ -81,15 +81,15 @@ properties:
         versionTemplate:
           type: object
           description: |
-            The template that controls properties of new CryptoKeyVersion 
-            instances created by either cryptoKeyVersions.create or 
+            The template that controls properties of new CryptoKeyVersion
+            instances created by either cryptoKeyVersions.create or
             auto-rotation.
           properties:
             protectionLevel:
               type: string
               default: SOFTWARE
               description: |
-                The level of protection to use when creating a CryptoKeyVersion 
+                The level of protection to use when creating a CryptoKeyVersion
                 based on the template.
               enum:
                 - PROTECTION_LEVEL_UNSPECIFIED

--- a/dm/templates/kms/kms.py.schema
+++ b/dm/templates/kms/kms.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: kms.py
 
-additionalProperties: false
-
 required:
   - keyRingName
 

--- a/dm/templates/logsink/logsink.py.schema
+++ b/dm/templates/logsink/logsink.py.schema
@@ -26,8 +26,6 @@ imports:
   - path: ../gcs_bucket/gcs_bucket.py
     name: gcs_bucket.py
 
-additionalProperties: false
-
 required:
   - destinationType
   - destinationName

--- a/dm/templates/managed_instance_group/examples/managed_instance_group.yaml
+++ b/dm/templates/managed_instance_group/examples/managed_instance_group.yaml
@@ -18,6 +18,5 @@ resources:
       targetSize: 3
       instanceTemplate:
         diskImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts
-        networks:
-          - name: default
+        network: default
         machineType: f1-micro

--- a/dm/templates/managed_instance_group/managed_instance_group.py.schema
+++ b/dm/templates/managed_instance_group/managed_instance_group.py.schema
@@ -24,8 +24,6 @@ imports:
   - path: ../instance_template/instance_template.py
     name: instance_template.py
 
-additionalProperties: false
-
 required:
   - targetSize
   - instanceTemplate
@@ -35,41 +33,6 @@ oneOf:
       - zone
   - required:
       - region
-
-definitions:
-  hasExternalIp:
-    type: boolean
-    default: true
-    description: |
-      Defines wether the instance will use an external IP from a shared
-      ephemeral IP address pool. If this is set to false, the instance
-      will not have an external IP.
-  natIP:
-    type: string
-    description: |
-      An external IP address associated with this instance. Specify an unused
-      static external IP address available to the project or leave this field
-      undefined to use an IP from a shared ephemeral IP address pool. If you
-      specify a static external IP address, it must live in the same region
-      as the zone of the instance.
-      If hasExternalIp is false this field is ignored.
-  subnetwork:
-    type: string
-    description: |
-      The URL of the Subnetwork resource for this instance. If the network
-      resource is in legacy mode, do not provide this property. If the network
-      is in auto subnet mode, providing the subnetwork is optional. If the
-      network is in custom subnet mode, then this field should be specified.
-      If you specify this property, you can specify the subnetwork as a full
-      or partial URL. For example, the following are all valid URLs:
-        - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
-        - regions/region/subnetworks/subnetwork
-  networkIP:
-    type: string
-    description: |
-      An IPv4 internal network address to assign to the instance for this
-      network interface. If not specified by the user, an unused internal IP
-      is assigned by the system.
 
 properties:
   name:
@@ -121,57 +84,12 @@ properties:
     description: |
       The instance template specified for this managed instance group.
       The template is used to create all new instances in the group.
-    additionalProperties: false
     oneOf:
-      - allOf:
-          - required:
-              - url
-          - not:
-              required:
-                - diskImage
-          - not:
-              required:
-                - network
-          - not:
-              required:
-                - networks
-          - not:
-              required:
-                - natIP
-          - not:
-              required:
-                - subnetwork
-          - not:
-              required:
-                - networkIP
-      - allOf:
-        - required:
-          - diskImage
-        - oneOf:
-          - allOf:
-              - required:
-                  - networks
-              - properties:
-                  networks:
-                    minItems: 1
-              - not:
-                  required:
-                    - network
-              - not:
-                  required:
-                    - natIP
-              - not:
-                  required:
-                    - subnetwork
-              - not:
-                  required:
-                    - networkIP
-          - allOf:
-              - required:
-                  - network
-              - not:
-                  required:
-                    - networks
+      - required:
+        - url
+      - required:
+        - diskImage
+        - network
     properties:
       url:
         type: string
@@ -190,40 +108,41 @@ properties:
       network:
         type: string
         description: |
-          Name of the network the instance will be connected to;
-          e.g., 'my-custom-network' or 'default'.
+          The URL or name of the network where the instance is placed;
+          e.g., 'my-custom-network' or 'global/networks/default'.
       hasExternalIp:
-        $ref: '#/definitions/hasExternalIp'
-      natIP:
-        $ref: '#/definitions/natIP'
-      subnetwork:
-        $ref: '#/definitions/subnetwork'
-      networkIP:
-        $ref: '#/definitions/networkIP'
-      networks:
-        type: array
+        type: boolean
+        default: true
         description: |
-          Networks the instance will be connected to;
-          e.g., 'my-custom-network' or 'default'.
-        items:
-          type: object
-          additionalProperties: false
-          required:
-            - name
-          properties:
-            name:
-              type: string
-              description: |
-                Name of the network the instance will be connected to;
-                e.g., 'my-custom-network' or 'default'.
-            hasExternalIp:
-              $ref: '#/definitions/hasExternalIp'
-            natIP:
-              $ref: '#/definitions/natIP'
-            subnetwork:
-              $ref: '#/definitions/subnetwork'
-            networkIP:
-              $ref: '#/definitions/networkIP'
+          Defines wether the instance will use an external IP from a shared
+          ephemeral IP address pool. If this is set to false, the instance
+          will not have an external IP.
+      natIp:
+        type: string
+        description: |
+          An external IP address associated with this instance. Specify an unused
+          static external IP address available to the project or leave this field
+          undefined to use an IP from a shared ephemeral IP address pool. If you
+          specify a static external IP address, it must live in the same region
+          as the zone of the instance.
+          If hasExternalIp is false this field is ignored.
+      subnetwork:
+        type: string
+        description: |
+          The URL of the Subnetwork resource for this instance. If the network
+          resource is in legacy mode, do not provide this property. If the network
+          is in auto subnet mode, providing the subnetwork is optional. If the
+          network is in custom subnet mode, then this field should be specified.
+          If you specify this property, you can specify the subnetwork as a full
+          or partial URL. For example, the following are all valid URLs:
+            - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
+            - regions/region/subnetworks/subnetwork
+      networkIp:
+        type: string
+        description: |
+          An IPv4 internal network address to assign to the instance for this
+          network interface. If not specified by the user, an unused internal IP
+          is assigned by the system.
       machineType:
         type: string
         default: n1-standard-1

--- a/dm/templates/nat_gateway/nat_gateway.py.schema
+++ b/dm/templates/nat_gateway/nat_gateway.py.schema
@@ -35,8 +35,6 @@ imports:
   - path: ../firewall/firewall.py
     name: firewall.py
 
-additionalProperties: false
-
 required:
   - network
   - subnetwork

--- a/dm/templates/network/network.py
+++ b/dm/templates/network/network.py
@@ -37,7 +37,6 @@ def generate_config(context):
     ]
 
     # Subnetworks:
-    out = {}
     for subnetwork in context.properties.get('subnetworks', []):
         subnetwork['network'] = network_self_link
         resources.append(
@@ -47,16 +46,6 @@ def generate_config(context):
                 'properties': subnetwork
             }
         )
-
-        out[subnetwork['name']] = {
-            'selfLink': '$(ref.{}.selfLink)'.format(subnetwork['name']),
-            'ipCidrRange': '$(ref.{}.ipCidrRange)'.format(subnetwork['name']),
-            'region': '$(ref.{}.region)'.format(subnetwork['name']),
-            'network': '$(ref.{}.network)'.format(subnetwork['name']),
-            'gatewayAddress': '$(ref.{}.gatewayAddress)'.format(
-                subnetwork['name']
-            )
-        }
 
     return {
         'resources':
@@ -70,10 +59,6 @@ def generate_config(context):
                 {
                     'name': 'selfLink',
                     'value': network_self_link
-                },
-                {
-                    'name': 'subnetworks',
-                    'value': out
                 }
             ]
     }

--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -24,8 +24,6 @@ info:
 imports:
   - path: subnetwork.py
 
-additionalProperties: false
-
 # required:
 #  - name
 

--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -61,36 +61,6 @@ outputs:
     - selfLink:
         type: string
         description: The URI (SelfLink) of the network resource.
-    - subnetworks:
-      type: array
-      description: Array of subnetwork` information.
-      items:
-        description: |
-          The name of the subnetwork resource. For example, the output can be
-          referenced as: $(ref.<my-network>.subnetworks.<subnetwork-name>.selfLink)
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for a subnetwork resource.
-            properties:
-              - selfLink:
-                  type: string
-                  description: The URI (SelfLink) of the subnet resource.
-              - region:
-                  type: string
-                  description: The name of the region where the subnetwork resides.
-              - network:
-                  type: string
-                  description: The URL of the network to which the subnetwork belongs.
-              - ipCidrRange:
-                  type: string
-                  description: |
-                    The range of internal addresses owned by the subnetwork.
-              - gatewayAddress:
-                  type: string
-                  description: |
-                    The gateway address for default routes to reach destination addresses
-                    outside this subnetwork.
 
 documentation:
   - templates/network/README.md

--- a/dm/templates/network/subnetwork.py
+++ b/dm/templates/network/subnetwork.py
@@ -17,7 +17,7 @@
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    name = context.properties.get('name', context.env['name'])
+    name = context.properties.get('name') or context.env['name']
     required_properties = ['network', 'ipCidrRange', 'region']
     optional_properties = [
         'enableFlowLogs',
@@ -43,31 +43,4 @@ def generate_config(context):
         }
     ]
 
-    output = [
-        {
-            'name': 'name',
-            'value': name
-        },
-        {
-            'name': 'selfLink',
-            'value': '$(ref.{}.selfLink)'.format(name)
-        },
-        {
-            'name': 'ipCidrRange',
-            'value': '$(ref.{}.ipCidrRange)'.format(name)
-        },
-        {
-            'name': 'region',
-            'value': '$(ref.{}.region)'.format(name)
-        },
-        {
-            'name': 'network',
-            'value': '$(ref.{}.network)'.format(name)
-        },
-        {
-            'name': 'gatewayAddress',
-            'value': '$(ref.{}.gatewayAddress)'.format(name)
-        }
-    ]
-
-    return {'resources': resources, 'outputs': output}
+    return {'resources': resources}

--- a/dm/templates/network/subnetwork.py.schema
+++ b/dm/templates/network/subnetwork.py.schema
@@ -46,8 +46,8 @@ properties:
     type: boolean
     default: true
     description: |
-      Defines whether the VMs in this subnetwork can access Google services 
-      without assigned external IP addresses. This field can be either set at the 
+      Defines whether the VMs in this subnetwork can access Google services
+      without assigned external IP addresses. This field can be either set at the
       resource creation time or updated using setPrivateIpGoogleAccess.
   secondaryIpRanges:
     type: array
@@ -63,30 +63,6 @@ properties:
   enableFlowLogs:
     type: boolean
     description: If "true", enables flow logging for the subnetwork.
-
-outputs:
-  properties:
-    - name:
-        type: string
-        description: The subnet resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the subnet resource.
-    - region:
-        type: string
-        description: The name of the region where the subnetwork resides.
-    - network:
-        type: string
-        description: The URL of the network to which the subnetwork belongs.
-    - ipCidrRange:
-        type: string
-        description: |
-          The range of internal addresses owned by the subnetwork.
-    - gatewayAddress:
-        type: string
-        description: |
-          The gateway address for default routes to reach destination addresses
-          outside this subnetwork.
 
 documentation:
   - templates/network/README.md

--- a/dm/templates/network/subnetwork.py.schema
+++ b/dm/templates/network/subnetwork.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Creates a subnetwork.
 
-additionalProperties: false
-
 required:
   - network
   - region

--- a/dm/templates/network_peering/network_peering.py.schema
+++ b/dm/templates/network_peering/network_peering.py.schema
@@ -24,8 +24,6 @@ info:
 imports:
   - path: network_peering.py
 
-additionalProperties: false
-
 required:
   - name
   - network

--- a/dm/templates/org_policy/org_policy.py.schema
+++ b/dm/templates/org_policy/org_policy.py.schema
@@ -20,8 +20,6 @@ info:
 imports:
   - path: org_policy.py
 
-additionalProperties: false
-
 required:
   - projectId
   - policies

--- a/dm/templates/project/project.py
+++ b/dm/templates/project/project.py
@@ -55,25 +55,13 @@ def generate_config(context):
     api_resources, api_names_list = activate_apis(context.properties)
     resources.extend(api_resources)
     resources.extend(create_service_accounts(context, project_id))
-
-    if (
-        context.properties.get('usageExportBucket', True) and
-        'api-compute.googleapis.com' in api_names_list
-    ):
-        resources.extend(create_bucket(context.properties))
-
+    resources.extend(create_bucket(context.properties))
     resources.extend(create_shared_vpc(project_id, context.properties))
 
-    if (
-        context.properties.get('removeDefaultVPC', True) and
-        'api-compute.googleapis.com' in api_names_list
-    ):
+    if context.properties.get('removeDefaultVPC', True):
         resources.extend(delete_default_network(api_names_list))
 
-    if (
-        context.properties.get('removeDefaultSA', True) and
-        'api-compute.googleapis.com' in api_names_list
-    ):
+    if context.properties.get('removeDefaultSA', True):
         resources.extend(delete_default_service_account(api_names_list))
 
     return {
@@ -111,24 +99,16 @@ def activate_apis(properties):
     concurrent_api_activation = properties.get('concurrentApiActivation')
     apis = properties.get('activateApis', [])
 
-    if 'storage-component.googleapis.com' not in apis:
-        if (
-            # Enable the storage-component API if the usage export bucket is enabled.
-            properties.get('usageExportBucket')
-        ):
-            apis.append('storage-component.googleapis.com')
-
-    if 'compute.googleapis.com' not in apis:
-        if (
-            properties.get('sharedVPCHost') or
-            properties.get('sharedVPC') or
-            properties.get('sharedVPCSubnets')
-        ):
-            apis.append('compute.googleapis.com')
+    # Enable the storage-component API if the usage export bucket is enabled.
+    if (
+            properties.get('usageExportBucket') and
+            'storage-component.googleapis.com' not in apis
+    ):
+        apis.append('storage-component.googleapis.com')
 
     resources = []
     api_names_list = ['billing']
-    for api in apis:
+    for api in properties.get('activateApis', []):
         depends_on = ['billing']
         # Serialize activation of all APIs by making apis[n]
         # depend on apis[n-1].
@@ -186,35 +166,38 @@ def create_shared_vpc_subnet_iam(context, dependencies, members_list):
     """ Grant the shared VPC subnet IAM permissions to Service Accounts. """
 
     resources = []
-
-    # Grant the Service Accounts access to the shared VPC subnets.
-    # Note that, until there is a subnetwork IAM patch support,
-    # setIamPolicy will overwrite any existing policies on the subnet.
-    for i, subnet in enumerate(
-            context.properties.get('sharedVPCSubnets'), 1
-        ):
-        resources.append(
-            {
-                'name': 'add-vpc-subnet-iam-policy-{}'.format(i),
-                'type': 'gcp-types/compute-beta:compute.subnetworks.setIamPolicy',  # pylint: disable=line-too-long
-                'metadata':
-                    {
-                        'dependsOn': dependencies,
-                    },
-                'properties':
-                    {
-                        'name': subnet['subnetId'],
-                        'project': context.properties['sharedVPC'],
-                        'region': subnet['region'],
-                        'bindings': [
-                            {
-                                'role': 'roles/compute.networkUser',
-                                'members': members_list
-                            }
-                        ]
-                    }
-            }
-        )
+    if (
+            context.properties.get('sharedVPCSubnets') and
+            context.properties.get('sharedVPC')
+    ):
+        # Grant the Service Accounts access to the shared VPC subnets.
+        # Note that, until there is a subnetwork IAM patch support,
+        # setIamPolicy will overwrite any existing policies on the subnet.
+        for i, subnet in enumerate(
+                context.properties.get('sharedVPCSubnets'), 1
+            ):
+            resources.append(
+                {
+                    'name': 'add-vpc-subnet-iam-policy-{}'.format(i),
+                    'type': 'gcp-types/compute-beta:compute.subnetworks.setIamPolicy',  # pylint: disable=line-too-long
+                    'metadata':
+                        {
+                            'dependsOn': dependencies,
+                        },
+                    'properties':
+                        {
+                            'name': subnet['subnetId'],
+                            'project': context.properties['sharedVPC'],
+                            'region': subnet['region'],
+                            'bindings': [
+                                {
+                                    'role': 'roles/compute.networkUser',
+                                    'members': members_list
+                                }
+                            ]
+                        }
+                }
+            )
 
     return resources
 
@@ -224,7 +207,7 @@ def create_service_accounts(context, project_id):
 
     resources = []
     network_list = ['serviceAccount:$(ref.project.projectNumber)@cloudservices.gserviceaccount.com'] # pylint: disable=line-too-long
-    service_account_dep = ["api-compute.googleapis.com"]
+    service_account_dep = []
     policies_to_add = []
 
     for service_account in context.properties['serviceAccounts']:
@@ -269,21 +252,12 @@ def create_service_accounts(context, project_id):
         for role in group['roles']:
             policies_to_add.append({'role': role, 'members': [group_name]})
 
-        # Check if the group needs shared VPC permissions. Put in
-        # a list to grant the shared VPC subnet IAM permissions.
-        if group.get('networkAccess'):
-            network_list.append(group_name)
-
     # Create the project IAM permissions.
     if policies_to_add:
         iam = create_project_iam(service_account_dep, policies_to_add)
         resources.extend(iam)
 
-    if (
-        not context.properties.get('sharedVPCHost') and
-        context.properties.get('sharedVPCSubnets') and
-        context.properties.get('sharedVPC')
-    ):
+    if not context.properties.get('sharedVPCHost'):
         # Create the shared VPC subnet IAM permissions.
         resources.extend(
             create_shared_vpc_subnet_iam(
@@ -300,46 +274,43 @@ def create_bucket(properties):
     """ Resources for the usage export bucket. """
 
     resources = []
+    if properties.get('usageExportBucket'):
+        bucket_name = '$(ref.project.projectId)-usage-export'
 
-    bucket_name = '$(ref.project.projectId)-usage-export'
-
-    # Create the bucket.
-    resources.append(
-        {
-            'name': 'create-usage-export-bucket',
-            'type': 'gcp-types/storage-v1:buckets',
-            'properties':
-                {
-                    'project': '$(ref.project.projectId)',
-                    'name': bucket_name
-                },
-            'metadata':
-                {
-                    'dependsOn': ['api-storage-component.googleapis.com']
-                }
-        }
-    )
-
-    # Set the project's usage export bucket.
-    resources.append(
-        {
-            'name':
-                'set-usage-export-bucket',
-            'action':
-                'gcp-types/compute-v1:compute.projects.setUsageExportBucket',  # pylint: disable=line-too-long
-            'properties':
-                {
-                    'project': '$(ref.project.projectId)',
-                    'bucketName': 'gs://' + bucket_name
-                },
-            'metadata': {
-                'dependsOn': [
-                    'create-usage-export-bucket',
-                    'api-compute.googleapis.com',
-                ]
+        # Create the bucket.
+        resources.append(
+            {
+                'name': 'create-usage-export-bucket',
+                'type': 'gcp-types/storage-v1:buckets',
+                'properties':
+                    {
+                        'project': '$(ref.project.projectId)',
+                        'name': bucket_name
+                    },
+                'metadata':
+                    {
+                        'dependsOn': ['api-storage-component.googleapis.com']
+                    }
             }
-        }
-    )
+        )
+
+        # Set the project's usage export bucket.
+        resources.append(
+            {
+                'name':
+                    'set-usage-export-bucket',
+                'action':
+                    'gcp-types/compute-v1:compute.projects.setUsageExportBucket',  # pylint: disable=line-too-long
+                'properties':
+                    {
+                        'project': '$(ref.project.projectId)',
+                        'bucketName': 'gs://' + bucket_name
+                    },
+                'metadata': {
+                    'dependsOn': ['create-usage-export-bucket']
+                }
+            }
+        )
 
     return resources
 

--- a/dm/templates/project/project.py.schema
+++ b/dm/templates/project/project.py.schema
@@ -24,84 +24,8 @@ imports:
 - path: ../iam_member/iam_member.py
   name: cft-iam_project_member.py
 
-additionalProperties: false
-
 required:
   - billingAccountId
-
-oneOf:
-  - required:
-      - sharedVPCHost
-    not:
-      required:
-        - sharedVPC
-        - sharedVPCSubnets
-  - required:
-      - sharedVPC
-    not:
-      required:
-        - sharedVPCHost
-  - allOf:
-    - not:
-        required:
-          - sharedVPC
-    - not:
-        required:
-          - sharedVPCHost
-    - not:
-        required:
-          - sharedVPCSubnets
-
-dependencies:
-  sharedVPCSubnets:
-    required:
-      - sharedVPC
-
-allOf:
-  - $ref: '#/definitions/networkAccess-requires-sharedVPCSubnets'
-
-definitions:
-  networkAccess-requires-sharedVPCSubnets:
-    oneOf:
-      - $ref: '#/definitions/no-sharedVPCSubnets'
-      - $ref: '#/definitions/sharedVPCSubnets'
-  no-sharedVPCSubnets:
-    allOf:
-      - not:
-          required:
-            - sharedVPCSubnets
-      - properties:
-          serviceAccounts:
-            items:
-              properties:
-                networkAccess:
-                  enum:
-                    - False
-          groups:
-            items:
-              properties:
-                networkAccess:
-                  enum:
-                    - False
-  sharedVPCSubnets:
-    allOf:
-      - required:
-          - sharedVPCSubnets
-      - properties:
-          serviceAccounts:
-            items:
-              properties:
-                networkAccess:
-                  enum:
-                    - True
-                    - False
-          groups:
-            items:
-              properties:
-                networkAccess:
-                  enum:
-                    - True
-                    - False
 
 properties:
   name:
@@ -139,7 +63,6 @@ properties:
       For example, 00E12A-0AB8B2-078CE8
   activateApis:
     type: array
-    uniqueItems: True
     items:
       type: string
     description: The list of APIs to enable for each project.
@@ -152,64 +75,41 @@ properties:
       (set to True).
   serviceAccounts:
     type: array
-    uniqueItems: True
     default: []
     items:
-      type: object
-      required:
-        - accountId
-        - roles
-      properties:
-        accountId:
+      accountId:
+        type: string
+        pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
+        description: The name used to create the service account.
+      displayName:
+        type: string
+        description: |
+          The name to display for the service account. If not set, `accountId`
+          is used as the display name.
+      roles:
+        type: array
+        items:
           type: string
-          pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
-          description: The name used to create the service account.
-        displayName:
-          type: string
-          description: |
-            The name to display for the service account. If not set, `accountId`
-            is used as the display name.
-        roles:
-          type: array
-          minItems: 1
-          items:
-            type: string
-            description: The list of roles to grant the service account.
-        networkAccess:
-          type: boolean
-          default: False
-          description: |
-            If True, grants the shared VPC subnet IAM permissions
-            to the service account for the subnet specified by the
-            `sharedVPCSubnets.subnetId` field.
-            This field must not be set if `sharedVPCHost` is True.
+          description: The list of roles to grant the service account.
+      networkAccess:
+        type: boolean
+        description: |
+          If True, grants the shared VPC subnet IAM permissions
+          to the service account for the subnet specified by the
+          `sharedVPCSubnets.subnetId` field.
+          This field must not be set if `sharedVPCHost` is True.
   groups:
     type: array
-    uniqueItems: True
     default: []
     items:
-      type: object
-      required:
-        - name
-        - roles
-      properties:
-        name:
+      name:
+        type: string
+        description: The name of the Google group.
+      roles:
+        type: array
+        items:
           type: string
-          description: The name of the Google group.
-        roles:
-          type: array
-          minItems: 1
-          items:
-            type: string
-            description: The list of roles to grant the Google group.
-        networkAccess:
-          type: boolean
-          default: False
-          description: |
-            If True, grants the shared VPC subnet IAM permissions
-            to the group for the subnet specified by the
-            `sharedVPCSubnets.subnetId` field.
-            This field must not be set if `sharedVPCHost` is True.
+          description: The list of roles to grant the Google group.
   concurrentApiActivation:
     type: boolean
     default: False
@@ -227,10 +127,8 @@ properties:
       in. The `sharedVPCHost` property cannot be set if this property is set.
   sharedVPCSubnets:
     type: array
-    uniqueItems: True
     description: |
       The IDs of specific shared VPC subnets to share in the new project.
-    minItems: 1
     items:
       subnetId:
         type: string

--- a/dm/templates/pubsub/pubsub.py.schema
+++ b/dm/templates/pubsub/pubsub.py.schema
@@ -18,8 +18,6 @@ info:
   description: |
     Creates a topic, optionally with multiple subscriptions.
 
-additionalProperties: false
-
 properties:
   topic:
     type: string

--- a/dm/templates/route/route.py.schema
+++ b/dm/templates/route/route.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: route.py
 
-additionalProperties: false
-
 required:
   - network
   - routes

--- a/dm/templates/runtime_config/runtime_config.py.schema
+++ b/dm/templates/runtime_config/runtime_config.py.schema
@@ -24,8 +24,6 @@ imports:
   - path: variable.py
   - path: waiter.py
 
-additionalProperties: false
-
 required:
   - config
 

--- a/dm/templates/runtime_config/variable.py.schema
+++ b/dm/templates/runtime_config/variable.py.schema
@@ -19,8 +19,6 @@ info:
     For more information on this resource, see
     https://cloud.google.com/deployment-manager/runtime-configurator/.
 
-additionalProperties: false
-
 required:
   - parent
   - variable

--- a/dm/templates/runtime_config/waiter.py.schema
+++ b/dm/templates/runtime_config/waiter.py.schema
@@ -19,8 +19,6 @@ info:
     For more information on this resource, see
     https://cloud.google.com/deployment-manager/runtime-configurator/creating-a-waiter.
 
-additionalProperties: false
-
 required:
   - parent
   - waiter

--- a/dm/templates/shared_vpc_subnet_iam/shared_vpc_subnet_iam.py.schema
+++ b/dm/templates/shared_vpc_subnet_iam/shared_vpc_subnet_iam.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Grants IAM roles to a user on a shared VPC subnetwork
 
-additionalProperties: false
-
 required:
   - subnets
 

--- a/dm/templates/ssl_certificate/ssl_certificate.py.schema
+++ b/dm/templates/ssl_certificate/ssl_certificate.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Supports creation of the SSL certificate resource.
 
-additionalProperties: false
-
 required:
   - privateKey
   - certificate

--- a/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
+++ b/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
@@ -23,8 +23,6 @@ info:
 imports:
   - path: stackdriver_metric_descriptor.py
 
-additionalProperties: false
-
 required:
   - type
   - metricKind

--- a/dm/templates/target_proxy/target_proxy.py.schema
+++ b/dm/templates/target_proxy/target_proxy.py.schema
@@ -27,8 +27,6 @@ imports:
   - path: ../ssl_certificate/ssl_certificate.py
     name: ssl_certificate.py
 
-additionalProperties: false
-
 required:
   - target
   - protocol

--- a/dm/templates/url_map/url_map.py.schema
+++ b/dm/templates/url_map/url_map.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group Inc.
   description: Supports creation of the URL Map resource.
 
-additionalProperties: false
-
 properties:
   name:
     type: string

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -17,8 +17,6 @@ info:
   author: Sourced Group
   description: Creates a VPN tunnel, gateway, and fowarding rules.
 
-additionalProperties: false
-
 required:
   - network
   - region


### PR DESCRIPTION
Based on https://github.com/urbn/cloud-foundation-toolkit/pull/1, review https://github.com/urbn/cloud-foundation-toolkit/commit/cf97524d6bb1284eca126f79defe5e9c5498346c?w=1 for clarity

## What

- Silly trailing whitespace fixes `?w=1` ftw when reviewing
- Big Query: Modified to pass in additional dependencies so views can depend on tables they use.
- Big Query: Modified to change DM resource names to match top-level name we define in the specification. This enables
  one deployment to have the two tables/views with the same name, but in different datasets. This is allowable by
  BigQuery, e.g., a manifest defining a table named "table" in a dataset named "dataset" would create a resource in
  that deployment named "table" - this change creates that resource as "dataset_table".  Resource names for the
  datasets and tables remain the same.
- KMS: Modified to support a single deployment containing keys w/ identical names that belong to distinct keyrings.
